### PR TITLE
Fix bug with guid + github username 

### DIFF
--- a/SSW.Rules.AzFuncs/Domain/FrontMatter.cs
+++ b/SSW.Rules.AzFuncs/Domain/FrontMatter.cs
@@ -10,7 +10,7 @@ public class FrontMatter
     public string ArchivedReason { get; set; }
 
     public string Title { get; set; }
-    public Guid Guid { get; set; }
+    public string Guid { get; set; }
     public string Uri { get; set; }
     public DateTime Created { get; set; }
     public List<Author> Authors { get; set; }

--- a/SSW.Rules.AzFuncs/Domain/LatestRules.cs
+++ b/SSW.Rules.AzFuncs/Domain/LatestRules.cs
@@ -6,7 +6,7 @@ public class LatestRules : BaseEntity
 {
     public string CommitHash { get; set; }
     public string RuleUri { get; set; }
-    public Guid RuleGuid { get; set; }
+    public string RuleGuid { get; set; }
     public string RuleName { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }

--- a/SSW.Rules.AzFuncs/Functions/Widget/GetLatestRules.cs
+++ b/SSW.Rules.AzFuncs/Functions/Widget/GetLatestRules.cs
@@ -21,13 +21,14 @@ public class GetLatestRules(ILoggerFactory loggerFactory, RulesDbContext context
         var query = HttpUtility.ParseQueryString(req.Url.Query);
         var skip = int.Parse(query["skip"] ?? "0");
         var take = int.Parse(query["take"] ?? "10");
-        var githubUsername = query["githubUsername"];
+        var githubUsername = query["githubUsername"].Trim('\"');
 
         _logger.LogInformation($"Fetching latest rules, Skip: {skip}, Take: {take}, GitHubUsername: {githubUsername}");
 
         var rules = await context.LatestRules.GetAll();
         var filteredRules = rules
-            .Where(r => string.IsNullOrEmpty(githubUsername) || r.CreatedBy == githubUsername)
+            .Where(r => string.IsNullOrEmpty(githubUsername) || r.GitHubUsername == githubUsername ||
+                        r.CreatedBy == githubUsername || r.UpdatedBy == githubUsername)
             .OrderByDescending(r => r.UpdatedAt)
             .Skip(skip)
             .Take(take);

--- a/docs/Functions/Functions.http
+++ b/docs/Functions/Functions.http
@@ -19,7 +19,7 @@ Content-Type: application/json
 # Widget - Get LatestRules (with GitHub)
 @skip = 0
 @take = 10
-@githubUsername = ""
+@githubUsername = "BrookJeynes"
 
 GET {{BaseApiUrl}}/GetLatestRules?skip={{skip}}&take={{take}}&githubUsername={{githubUsername}}
 Content-Type: application/json


### PR DESCRIPTION
- Changes `Guid`'s to `string` as Rules Guid seem to not work with the c# `Guid` type 
- Adds a `trim` to the `GitHubUserName` as it was coming back with extra `""` 