### PR TITLE
🐛 Fix Query for Not Showing Same Rules on Widget

### DIFF
--- a/SSW.Rules.AzFuncs/Functions/Widget/GetLatestRules.cs
+++ b/SSW.Rules.AzFuncs/Functions/Widget/GetLatestRules.cs
@@ -29,6 +29,8 @@ public class GetLatestRules(ILoggerFactory loggerFactory, RulesDbContext context
         var filteredRules = rules
             .Where(r => string.IsNullOrEmpty(githubUsername) || r.GitHubUsername == githubUsername ||
                         r.CreatedBy == githubUsername || r.UpdatedBy == githubUsername)
+            .GroupBy(r => r.RuleGuid)
+            .Select(group => group.First())
             .OrderByDescending(r => r.UpdatedAt)
             .Skip(skip)
             .Take(take);


### PR DESCRIPTION
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1197

This PR:
- Updated `GetLatestRules` query to filter out rules with the same id and thus not return duplicate rules