### PR TITLE
📦 Added extension bundle

### DIFF
--- a/SSW.Rules.AzFuncs/host.json
+++ b/SSW.Rules.AzFuncs/host.json
@@ -1,12 +1,16 @@
 {
-    "version": "2.0",
-    "logging": {
-        "applicationInsights": {
-            "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
-            },
-            "enableLiveMetricsFilters": true
-        }
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      },
+      "enableLiveMetricsFilters": true
     }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.0.0, 5.0.0)"
+  }
 }


### PR DESCRIPTION
Added extension bundle as we noticed build errors on overview page staging function app

![image](https://github.com/user-attachments/assets/f592ca14-b4c7-4f81-9f17-c134eb642b31)
**Figure: [sswrules-staging-functions](https://portal.azure.com/#@sswcom.onmicrosoft.com/resource/subscriptions/b8b18dcf-d83b-47e2-9886-00c2e983629e/resourceGroups/SSW.Rule/providers/Microsoft.Web/sites/sswrules-staging-functions/appServices)**

## Error details:

Error code
AZFD0005
Level
Error
Last occurred
6 September 2024 at 10:12:27 am GMT+8
Help link
https://go.microsoft.com/fwlink/?linkid=2224847
Message
Error building configuration in an external startup class.
Details
Microsoft.Azure.WebJobs.Script.ExternalStartupException : Error building configuration in an external startup class. ---> Microsoft.Azure.WebJobs.Script.HostInitializationException : Referenced bundle Microsoft.Azure.Functions.ExtensionBundle of version 1.8.1 does not meet the required minimum version of 2.6.1. Update your extension bundle reference in host.json to reference 2.6.1 or later. For more information see https://aka.ms/func-min-bundle-versions. at Microsoft.Azure.WebJobs.Script.DependencyInjection.ScriptStartupTypeLocator.ValidateBundleRequirements(ExtensionBundleDetails bundleDetails) at /_/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs : 267 at async Microsoft.Azure.WebJobs.Script.DependencyInjection.ScriptStartupTypeLocator.GetExtensionsStartupTypesAsync() at /_/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs : 91 at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() at Microsoft.Azure.WebJobs.Script.DependencyInjection.ScriptStartupTypeLocator.<.ctor>b__10_0() at /_/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs : 53 at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode) at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication,Boolean useDefaultConstructor) at System.Lazy`1.CreateValue() at System.Lazy`1.get_Value() at Microsoft.Azure.WebJobs.Script.DependencyInjection.ScriptStartupTypeLocator.GetStartupTypes() at /_/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs : 68 at Microsoft.Azure.WebJobs.WebJobsBuilderExtensions.UseExternalConfigurationStartup(IWebJobsConfigurationBuilder builder,IWebJobsStartupTypeLocator startupTypeLocator,WebJobsBuilderContext context,ILoggerFactory loggerFactory) at D:\a\_work\1\s\src\Microsoft.Azure.WebJobs.Host\Hosting\WebJobsBuilderExtensions.cs : 362 at Microsoft.Azure.WebJobs.Script.ScriptHostBuilderExtensions.<>c__DisplayClass7_3.<AddScriptHostCore>b__8(IWebJobsStartupTypeLocator locator) at /_/src/WebJobs.Script/ScriptHostBuilderExtensions.cs : 263 End of inner exception
Hit count
8
