### PR TITLE
Revert "📦 Upgraded package 8 - Microsoft.Extensions.Configuration.Binder"

### DIFF
--- a/OidcApiAuthorization/OidcApiAuthorization.csproj
+++ b/OidcApiAuthorization/OidcApiAuthorization.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
       <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.3" />
       <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.0.3" />


### PR DESCRIPTION
Reverts SSWConsulting/SSW.Rules.Functions#77'

Upgrade of `Microsoft.Extensions.Configuration.Binder` from 8.0.0 to 8.0.2 caused of functions unavailability after deployment
