### PR TITLE
Refactor GetBookmarkStatusFunction response logic

### DIFF
--- a/SSW.Rules.AzFuncs/Functions/Bookmarks/GetBookmarkStatusFunction.cs
+++ b/SSW.Rules.AzFuncs/Functions/Bookmarks/GetBookmarkStatusFunction.cs
@@ -51,7 +51,7 @@ public class GetBookmarkStatusFunction(ILoggerFactory loggerFactory, RulesDbCont
         }
         else
         {
-            _logger.LogInformation($"Could find results for rule id: {ruleGuid}, and user: {userId}");
+            _logger.LogInformation($"✅ Found results for rule id: {ruleGuid}, and user: {userId}");
         }
 
         return req.CreateJsonResponse(new

--- a/SSW.Rules.AzFuncs/Functions/Bookmarks/GetBookmarkStatusFunction.cs
+++ b/SSW.Rules.AzFuncs/Functions/Bookmarks/GetBookmarkStatusFunction.cs
@@ -45,7 +45,7 @@ public class GetBookmarkStatusFunction(ILoggerFactory loggerFactory, RulesDbCont
             .Query(q => q.Where(w => w.RuleGuid == ruleGuid && w.UserId == userId));
         
         var bookmarkStatus = bookmarks.Any();
-        if (bookmarkStatus)
+        if (!bookmarkStatus)
         {
             _logger.LogInformation($"Could not find results for rule id: {ruleGuid}, and user: {userId}");
         }

--- a/SSW.Rules.AzFuncs/Functions/Bookmarks/GetBookmarkStatusFunction.cs
+++ b/SSW.Rules.AzFuncs/Functions/Bookmarks/GetBookmarkStatusFunction.cs
@@ -1,9 +1,7 @@
 using System.Net;
-using AzureGems.CosmosDB;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
-using SSW.Rules.AzFuncs.Domain;
 using SSW.Rules.AzFuncs.helpers;
 using SSW.Rules.AzFuncs.Persistence;
 
@@ -42,25 +40,21 @@ public class GetBookmarkStatusFunction(ILoggerFactory loggerFactory, RulesDbCont
         }
 
         _logger.LogInformation("Checking for bookmark on rule: {0} and user: {1}", ruleGuid, userId);
-        var bookmarks =
-            await dbContext.Bookmarks.Query(q => q.Where(w => w.RuleGuid == ruleGuid && w.UserId == userId));
+        var bookmarks = await dbContext
+            .Bookmarks
+            .Query(q => q.Where(w => w.RuleGuid == ruleGuid && w.UserId == userId));
         
-        if (bookmarks.Any())
+        var bookmarkStatus = bookmarks.Any();
+        if (bookmarkStatus)
         {
-            return req.CreateJsonResponse(new
-            {
-                error = false,
-                message = "",
-                bookmarkStatus = true,
-            });
+            _logger.LogInformation($"Could not find results for rule id: {ruleGuid}, and user: {userId}");
         }
 
-        _logger.LogInformation($"Could not find results for rule id: {ruleGuid}, and user: {userId}");
         return req.CreateJsonResponse(new
         {
             error = false,
             message = "",
-            bookmarkStatus = false,
-        }, HttpStatusCode.NotFound);
+            bookmarkStatus,
+        });
     }
 }

--- a/SSW.Rules.AzFuncs/Functions/Bookmarks/GetBookmarkStatusFunction.cs
+++ b/SSW.Rules.AzFuncs/Functions/Bookmarks/GetBookmarkStatusFunction.cs
@@ -49,6 +49,10 @@ public class GetBookmarkStatusFunction(ILoggerFactory loggerFactory, RulesDbCont
         {
             _logger.LogInformation($"Could not find results for rule id: {ruleGuid}, and user: {userId}");
         }
+        else
+        {
+            _logger.LogInformation($"Could find results for rule id: {ruleGuid}, and user: {userId}");
+        }
 
         return req.CreateJsonResponse(new
         {


### PR DESCRIPTION
We are currently observing numerous `404 NotFound` responses from the `GetBookmarkStatusFunction` in the client Application Insights. The current logic generates two types of responses:

- **When bookmark is found:**

```
if (bookmarks.Any())
{
    return req.CreateJsonResponse(new
    {
        error = false,
        message = "",
        bookmarkStatus = true,
    });
}
```

- **When bookmark is not found:**
```
return req.CreateJsonResponse(new
{
    error = false,
    message = "",
    bookmarkStatus = false,
}, HttpStatusCode.NotFound);
```

In both cases, the `error` property is set to `false`, which indicates a successful operation. The only distinction is the `bookmarkStatus` property and the different status codes (200 vs. 404). However, the front-end app relies on the `bookmarkStatus` property alone to display different icons, while Application Insights on the front end logs any 400-500 status codes as failures automatically.

**Suggested Improvement**

To streamline this logic, I’ve updated the response to a single format which makes it generic, returning a 200 OK status code in all cases. This change removes the 404 response for the "not found" case, as it conflicts with the `error = false` indicator and avoids marking these responses as failures.

```
var bookmarkStatus = bookmarks.Any();
if (bookmarkStatus)
{
    _logger.LogInformation($"Could not find results for rule id: {ruleGuid}, and user: {userId}");
}

return req.CreateJsonResponse(new
{
    error = false,
    message = "",
    bookmarkStatus,
});
```

Now, the response is a unified JSON object that differs only by the `bookmarkStatus` property, with a consistent 200 OK status code. This will ensure Application Insights does not log these responses as failures, aligning the backend response with frontend expectations.

**Logging:** The conditional `_logger.LogInformation` also logs when no bookmarks are found in back-end, making it easier to track missing bookmarks if needed.

[Application Insights](https://portal.azure.com/#@sswcom.onmicrosoft.com/resource/subscriptions/b8b18dcf-d83b-47e2-9886-00c2e983629e/resourceGroups/SSW.Rule/providers/microsoft.insights/components/sswrules/failures)
![image](https://github.com/user-attachments/assets/8b25a751-fddb-45a5-8390-434197f48e8d)
**Figure: The same function for different rules and users are logged as failures, in case it shouldn't be failure**
