### PR TITLE
Adding support for api aud values

### DIFF
--- a/Azure/Program.fs
+++ b/Azure/Program.fs
@@ -3,6 +3,7 @@ open Farmer
 open Farmer.Builders
 
 let audience = Environment.GetEnvironmentVariable  "AUTH0_AUDIENCE"
+let apiAudience = Environment.GetEnvironmentVariable "AUTH0_APIAUDIENCE"
 let issuer = Environment.GetEnvironmentVariable  "AUTH0_ISSUER"
 let mutable namePrefix = Environment.GetEnvironmentVariable "AZURE_RG_PREFIX"
 let gitHubToken = Environment.GetEnvironmentVariable "GITHUB_TOKEN" 
@@ -33,6 +34,7 @@ let myFunctions = functions {
     setting "CMS_OAUTH_CLIENT_ID" cmsOAuthClientId
     setting "CMS_OAUTH_CLIENT_SECRET" cmsOAuthClientSecret
     setting "OidcApiAuthorizationSettings:Audience" audience
+    setting "OidcApiAuthorizationSettings:ApiAudience" apiAudience
     setting "OidcApiAuthorizationSettings:IssuerUrl" issuer
     setting "CosmosDb:Account" myCosmosDb.Endpoint
     setting "CosmosDb:Key" myCosmosDb.PrimaryKey

--- a/OidcApiAuthorization/Models/OidcApiAuthorizationSettings.cs
+++ b/OidcApiAuthorization/Models/OidcApiAuthorizationSettings.cs
@@ -21,6 +21,8 @@ public class OidcApiAuthorizationSettings
     /// </remarks>
     public string Audience { get; set; }
 
+    public string ApiAudience { get; set; }
+
     /// <summary>
     /// The URL of the Open ID Connect provider (issuer) that will perform API authorization.
     /// </summary>

--- a/OidcApiAuthorization/OidcApiAuthorizationService.cs
+++ b/OidcApiAuthorization/OidcApiAuthorizationService.cs
@@ -19,6 +19,7 @@ namespace OidcApiAuthorization;
 
         private readonly string _issuerUrl = null;
         private readonly string _audience = null;
+        private readonly string _apiAudience = null;
 
         public OidcApiAuthorizationService(
             IOptions<OidcApiAuthorizationSettings> apiAuthorizationSettingsOptions,
@@ -28,6 +29,7 @@ namespace OidcApiAuthorization;
         {
             _issuerUrl = apiAuthorizationSettingsOptions?.Value?.IssuerUrl;
             _audience = apiAuthorizationSettingsOptions?.Value?.Audience;
+            _apiAudience = apiAuthorizationSettingsOptions?.Value?.ApiAudience;
 
             _authorizationHeaderBearerTokenExractor = authorizationHeaderBearerTokenExractor;
 
@@ -86,7 +88,7 @@ namespace OidcApiAuthorization;
                     var tokenValidationParameters = new TokenValidationParameters
                     {
                         RequireSignedTokens = true,
-                        ValidAudience = _audience,
+                        ValidAudiences = new List<string> { _audience, _apiAudience },
                         ValidateAudience = true,
                         ValidIssuer = _issuerUrl,
                         ValidateIssuer = true,


### PR DESCRIPTION
OAuth is setup a little incorrectly as we shouldn't be allowing ID token, instead we should be allowing access tokens. This PR is adding support for access tokens and allowing the audience value to be an API uri.